### PR TITLE
First version of the images clean scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,5 @@ before_script:
     - shellcheck $(find . -type f -name "*.sh")
   
 script:
-    # Finally executing the scripts
     - bash $HOST_CLOUD
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 
+notifications:
+  email: false
+
 sudo: required
 
 env:
@@ -7,7 +10,7 @@ env:
         #- HOST_CLOUD=gce_clean_images.sh
         - HOST_CLOUD=aws_clean_images.sh
         #- HOST_CLOUD=os_clean_images.sh
-        - AWS_ONLY=aws_del_old_snaps.sh
+        #- AWS_ONLY=aws_del_old_snaps.sh
 
 addons:
     apt:
@@ -15,6 +18,8 @@ addons:
             - debian-sid
         packages:
             - shellcheck # code review tool for bash script
+            
+install: true
 
 before_script:
     # Check bash scripts
@@ -23,7 +28,6 @@ before_script:
 script:
     # Finally executing the scripts  
     - travis_retry bash $HOST_CLOUD
-
-after_script:
     # Execute different script for AWS
-    - travis retry bash $AWS_ONLY
+    #- travis retry bash $AWS_ONLY
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: python
+
+sudo: required
+
+env:
+    matrix:
+        #- HOST_CLOUD=gce_clean_images.sh
+        - HOST_CLOUD=aws_clean_images.sh
+        #- HOST_CLOUD=os_clean_images.sh
+        - AWS_ONLY=aws_del_old_snaps.sh
+
+addons:
+    apt:
+        sources:
+            - debian-sid
+        packages:
+            - shellcheck # code review tool for bash script
+
+before_script:
+    # Check bash scripts
+    - shellcheck $(find . -type f -name "*.sh")
+  
+script:
+    # Finally executing the scripts  
+    - travis_retry bash $HOST_CLOUD
+
+after_script:
+    # Execute different script for AWS
+    - travis retry bash $AWS_ONLY

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python
+language: C
 
 notifications:
   email: false
@@ -7,27 +7,27 @@ sudo: required
 
 env:
     matrix:
-        #- HOST_CLOUD=gce_clean_images.sh
+        - HOST_CLOUD=gce_clean_images.sh
         - HOST_CLOUD=aws_clean_images.sh
-        #- HOST_CLOUD=os_clean_images.sh
-        #- AWS_ONLY=aws_del_old_snaps.sh
+        - HOST_CLOUD=os_clean_images.sh
 
-addons:
-    apt:
-        sources:
-            - debian-sid
-        packages:
-            - shellcheck # code review tool for bash script
-            
+before_install:
+    # Due to the following Bug: https://github.com/travis-ci/travis-ci/issues/7940
+    # To be removed in future revisions once bug is solved
+    - sudo rm -f /etc/boto.cfg
+
 install: true
 
 before_script:
-    # Check bash scripts
+    # Installing common tools (pip and jq) and check bash scripts
+    - curl -O https://bootstrap.pypa.io/get-pip.py
+    - python get-pip.py --user
+    - export PATH=~/.local/bin:$PATH
+    - pip install --upgrade pip
+    - sudo apt-get install shellcheck jq -y
     - shellcheck $(find . -type f -name "*.sh")
   
 script:
-    # Finally executing the scripts  
-    - travis_retry bash $HOST_CLOUD
-    # Execute different script for AWS
-    #- travis retry bash $AWS_ONLY
+    # Finally executing the scripts
+    - bash $HOST_CLOUD
     

--- a/aws_clean_images.sh
+++ b/aws_clean_images.sh
@@ -76,7 +76,7 @@ s3_buckets=("us-east-1" "eu-central-1")
 for buck in ${s3_buckets[*]}; do
 
     echo -e "AWS S3 $buck - Looking for old KubeNow bucket objects:\n"
-    aws s3 ls s3://kubenow-$buck --region $buck --human-readable | grep -E 'kubenow-v([0-9]*)([ab0-9]*)-([0-9]*)-([a-z0-9]*)-([test]*)([current]*).qcow2([.md5]*)' > /tmp/aws_s3_objs.txt
+    aws s3 ls s3://kubenow-"$buck" --region "$buck" --human-readable | grep -E 'kubenow-v([0-9]*)([ab0-9]*)-([0-9]*)-([a-z0-9]*)-([test]*)([current]*).qcow2([.md5]*)' > /tmp/aws_s3_objs.txt
 
     no_obj_to_check=$(wc -l < /tmp/aws_s3_objs.txt)
     echo -e "No of bucket object to be checked: $no_obj_to_check\n"
@@ -86,13 +86,13 @@ for buck in ${s3_buckets[*]}; do
     if [ "$no_obj_to_check" -gt "0" ]; then
 
         while read -r line; do
-            obj_date=$(echo $line | awk {'print $1'})
-            obj_name=$(echo $line | awk {'print $5'})
+            obj_date=$(echo "$line" | awk '{print $1}')
+            obj_name=$(echo "$line" | awk '{print $5}')
 
             if [[ ! "$obj_date" > "$del_date" ]]; then
                 echo -e "Following old KubeNow bucket object dated: $obj_date is found\nName: $obj_name\n"
                 echo -e "Starting the delete bucket object: $obj_name...\n"
-                aws s3 rm "s3://kubenow-$buck/$obj_name" --region $buck
+                aws s3 rm "s3://kubenow-$buck/$obj_name" --region "$buck"
                 counter_del_s3_obj=$((counter_del_s3_obj+1))
             fi
         done < /tmp/aws_s3_objs.txt

--- a/aws_clean_images.sh
+++ b/aws_clean_images.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Script to delete AMI older than n no of days
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Installing necessary tool for the script: awscli and jq
+sudo apt-get update && sudo apt-get upgrade
+sudo apt-get install awscli jq -y
+
+# Current list of regions we work with
+aws_regions=("ca-central-1" "eu-central-1" "eu-west-1" "eu-west-2" "us-east-1" "us-east-2" "us-west-1" "us-west-2")
+
+echo -e "----------------------------------\n   $(date)   \n----------------------------------"
+del_date=$(date +"%Y-%m-%d" --date="1 days ago")
+echo -e "Amazon Web Services - Looking for old KubeNow's AMIs:\n "
+
+# Now we start the process of deregistering the old Kubenow AMI across all the other regions
+for reg in ${aws_regions[*]}; do
+        
+        # We update the default region so to correctly perform checks in each region via awscli
+        AWS_DEFAULT_REGION="$reg"
+        printf "Current region is: %s\n" "$AWS_DEFAULT_REGION"
+        
+        # Extracting both KubeNow images that are flagged as "test" or "current"
+        aws ec2 describe-images --filters "Name=name,Values=kubenow-*-*" > /tmp/aws_out_images.json
+        tot_no_amis=$(grep -c -i imageid < /tmp/aws_out_images.json)
+
+        if [ "$tot_no_amis" -gt "0" ]; then
+            # Finding Image IDs of AMIs older than 3 days which needed to be deregistered
+            counter_del_img=0
+            counter_del_snap=0
+            index=0
+            while [ "$index" -lt "$tot_no_amis" ]; do
+
+                img_date=$(jq ".Images[$index] | .CreationDate" /tmp/aws_out_images.json | sed -e 's/^"//' -e 's/"$//' -e 's/T.*//')
+
+                if [ "$img_date" == "$del_date" ]; then
+                    # Extracting AMI's "Name" and "ImageId"
+                    name=$(jq ".Images[$index] | .Name" /tmp/aws_out_images.json | sed -e 's/^"//' -e 's/"$//')
+                    ami_id_to_deregister=$(jq ".Images[$index] | .ImageId" /tmp/aws_out_images.json | sed -e 's/^"//' -e 's/"$//')
+                    echo -e "Following old AMI dated $img_date is found \nName: $name \nAMI ID:$ami_id_to_deregister\n"
+
+                    # Find if there are any snapshots attached to the Image need to be deregister
+                    aws ec2 describe-images --image-ids "$ami_id_to_deregister" | grep snap | awk ' { print $2 }' | sed -e 's/^"//' -e 's/,$//' -e 's/"$//' > /tmp/old_snaps.txt                  
+                    
+                    # Deregistering the AMI
+                    echo -e "Starting the deregister of KubewNow AMI: $ami_id_to_deregister...\n"
+                    aws ec2 deregister-image --image-id "$ami_id_to_deregister"
+                    counter_del_img=$((counter_del_img+1))
+                    
+                    # Deleting snapshots attached to AMI
+                    while read -r line; do 
+                        echo -e "Deleting the associated snapshots: $line \n"
+                        aws ec2 delete-snapshot --snapshot-id "$line"
+                        counter_del_snap=$((counter_del_snap+1))
+                    done < /tmp/old_snaps.txt
+                fi
+
+                index=$((index+1))
+            done
+            
+            if [ "$counter_del_img" == "0" ]; then
+                echo -e "No old images dated $del_date were found \n"
+            fi
+            
+        else
+            echo -e "No KubeNow AMIs flagged as test or current found"
+        fi
+done
+
+# Now taking care of the S3 bucket for KubeNow images. Extracting List of objects
+echo -e "AWS S3 - Looking for old KubeNow bucket objects:\n"
+aws s3 ls s3://kubenow-us-east-1 --region us-east-1 --human-readable | grep -E 'kubenow-v([0-9]*)([ab0-9]*)-([0-9]*)-([a-z0-9]*)-([test]*)([current]*).qcow2' > /tmp/aws_s3_objs.txt
+
+no_obj_to_check=$(wc -l < /tmp/aws_s3_objs.txt)
+echo -e "No of bucket object to be checked: $no_obj_to_check\n"
+
+counter_del_s3_obj=0
+
+if [ "$no_obj_to_check" -gt "0" ]; then
+
+    while read -r line; do
+        obj_date=$(echo $line | awk {'print $1'})
+        obj_name=$(echo $line | awk {'print $5'})
+    
+        if [ "$obj_date" == "$del_date" ]; then
+            echo -e "Following old KubeNow bucket object dated: $obj_date is found\nName: $obj_name\n"
+            echo -e "Starting the delete bucket object: $obj_name...\n"
+            aws s3 rm "s3://kubenow-us-east-1/$obj_name"
+            counter_del_s3_obj=$((counter_del_s3_obj+1))
+        fi
+    done < /tmp/aws_s3_objs.txt
+    
+    if [ "$counter_del_s3_obj" == "0" ]; then
+        echo -e "No old bucket objects dated $del_date were found \n"
+    fi
+    
+else
+   echo -e "\nNo KubeNow bucket objects flagged as test or current found"
+fi
+
+echo -e "\nNo of deleted of AMI: $counter_del_img\nNo of deleted snapshots: $counter_del_snap\nNo of deleted bucket object: $counter_del_s3_obj\nDone.\n"

--- a/aws_clean_images.sh
+++ b/aws_clean_images.sh
@@ -5,12 +5,12 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
+# Installing necessary tool for the script: awscli and jq
+pip install awscli --upgrade --user
+
 # Execute different script only for AWS and before main ones
 # Reason is to avoid concurrent APIs call (e.g. deletion of an AMI and checking if that AMI exists)
 bash aws_del_old_snaps.sh
-
-# Installing necessary tool for the script: awscli and jq
-pip install awscli --upgrade --user
 
 # Current list of regions we work with
 aws_regions=("ca-central-1" "eu-central-1" "eu-west-1" "eu-west-2" "us-east-1" "us-east-2" "us-west-1" "us-west-2")

--- a/aws_del_old_snaps.sh
+++ b/aws_del_old_snaps.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Script to delete old unpaired snapshots
+
+# Installing necessary tool for the script: awscli and jq
+sudo apt-get update && sudo apt-get upgrade -y
+sudo apt-get install awscli jq -y
+
+# Current list of regions we work with
+aws_regions=("ca-central-1" "eu-central-1" "eu-west-1" "eu-west-2" "us-east-1" "us-east-2" "us-west-1" "us-west-2")
+
+echo -e "\n----------------------------------\n   $(date)   \n----------------------------------"
+#del_date=$(date +"%Y-%m-%d" --date="1 days ago")
+echo -e "Amazon Web Services - Looking for old unpaired snaposhots:\n "
+
+# Now we start the process of deregistering the old Kubenow AMI across all the other regions
+for reg in ${aws_regions[*]}; do
+        
+        # We update the default region so to correctly perform checks in each region via awscli
+        AWS_DEFAULT_REGION="$reg"
+        echo -e "Current region is: $AWS_DEFAULT_REGION\n"
+        
+        # Extracting both KubeNow images that are flagged as "test" or "current"
+        aws ec2 describe-snapshots --owner-ids 105135433346 --query 'Snapshots[*].{ID:SnapshotId,Description:Description}' > /tmp/aws_snaps.json
+        sed -i '1s/^/{"Snapshots":/' /tmp/aws_snaps.json
+        sed -i "$ a }" /tmp/aws_snaps.json
+        tot_no_snaps=$(grep -c -i ID < /tmp/aws_snaps.json)
+
+        if [ "$tot_no_snaps" -gt "0" ]; then
+            # Finding if the AMI which the current snapshot has been created for still exist. If not, we can delete snapshot
+            echo -e "Total of current snapshot is: $tot_no_snaps\n"
+            counter_del_snap=0
+            index=0
+            while [ "$index" -lt "$tot_no_snaps" ]; do
+                 
+                # Extracting AMI's ID from snapshot's description field
+                ami_id_to_check=$(jq ".Snapshots[$index] | .Description" /tmp/aws_snaps.json | egrep -o -m1 "ami-([a-z0-9]*)")
+                snap_id=$(jq ".Snapshots[$index] | .ID" /tmp/aws_snaps.json | sed -e 's/^"//' -e 's/"$//')
+
+                # When copying an AMI from one region to another, both the source and the destination AMI ids are listed. We need to keep and check only first id
+                no_of_rel_amis=$(echo "$ami_id_to_check" | wc -w)
+                
+                if [ "$no_of_rel_amis" == "0" ] && [ -z "$ami_id_to_check" ]; then
+                    # This should never happen. However if something goes wrong, then we avoid to call APIs which will fail otherwise
+                    echo -e "Oops. Something went wrong at this point.\nNo of AMI ids to be checked seems zero. This should not be the case\n"
+                    exit 1
+                elif [ "$no_of_rel_amis" -gt "1" ]; then
+                    ami_id_to_check=$(echo "$ami_id_to_check" | awk NR==1{'print $1'})
+                fi
+                 
+                echo -e "Snapshot id: $snap_id"
+                echo -e "Related AMI Id to be checked: $ami_id_to_check"
+                
+                # Checking whether or not AMI still exists
+                aws ec2 describe-images --image-ids "$ami_id_to_check" > /tmp/output_AMI_check 2> /tmp/out_err_AMI_check
+                aws_exit_code=$?
+                aws_string_err=$(grep -o "does not exist" < /tmp/out_err_AMI_check)
+
+                if [ "$aws_exit_code" == "0" ]; then
+                    echo -e "AMI id: $ami_id_to_check still exists. Snapshot id: $snap_id will not be deleted.\n"
+                elif [ "$aws_exit_code" == "255" ] && [ -n "aws_string_err" ]; then
+                    echo -e "AMI id: $ami_id_to_check does not exist anymore. Snapshot id: $snap_id will be deleted.\n"
+                    echo -e "Deleting the snapshots id: $snap_id \n"
+                    aws ec2 delete-snapshot --snapshot-id "$snap_id"
+                    counter_del_snap=$((counter_del_snap+1))
+                fi
+
+                index=$((index+1))
+            done
+            
+            if [ "$counter_del_snap" == "0" ]; then
+                echo -e "No old unpaired snapshots were found \n"
+            fi
+        else
+            echo -e "There are no available snapshots in the current region: $AWS_DEFAULT_REGION"
+        fi
+done
+
+echo -e "\nNo of deleted of snapshots: $counter_del_snap\nDone.\n"
+
+exit $?

--- a/aws_del_old_snaps.sh
+++ b/aws_del_old_snaps.sh
@@ -32,7 +32,7 @@ for reg in ${aws_regions[*]}; do
             while [ "$index" -lt "$tot_no_snaps" ]; do
                  
                 # Extracting AMI's ID from snapshot's description field
-                ami_id_to_check=$(jq ".Snapshots[$index] | .Description" /tmp/aws_snaps.json | egrep -o -m1 "ami-([a-z0-9]*)")
+                ami_id_to_check=$(jq ".Snapshots[$index] | .Description" /tmp/aws_snaps.json | grep -E -o -m1 "ami-([a-z0-9]*)")
                 snap_id=$(jq ".Snapshots[$index] | .ID" /tmp/aws_snaps.json | sed -e 's/^"//' -e 's/"$//')
 
                 # When copying an AMI from one region to another, both the source and the destination AMI ids are listed. We need to keep and check only first id
@@ -43,7 +43,7 @@ for reg in ${aws_regions[*]}; do
                     echo -e "Oops. Something went wrong at this point.\nNo of AMI ids to be checked seems zero. This should not be the case\n"
                     exit 1
                 elif [ "$no_of_rel_amis" -gt "1" ]; then
-                    ami_id_to_check=$(echo "$ami_id_to_check" | awk NR==1{'print $1'})
+                    ami_id_to_check=$(echo "$ami_id_to_check" | awk NR==1'{print $1}')
                 fi
                  
                 echo -e "Snapshot id: $snap_id"
@@ -56,7 +56,7 @@ for reg in ${aws_regions[*]}; do
 
                 if [ "$aws_exit_code" == "0" ]; then
                     echo -e "AMI id: $ami_id_to_check still exists. Snapshot id: $snap_id will not be deleted.\n"
-                elif [ "$aws_exit_code" == "255" ] && [ -n "aws_string_err" ]; then
+                elif [ "$aws_exit_code" == "255" ] && [ -n "$aws_string_err" ]; then
                     echo -e "AMI id: $ami_id_to_check does not exist anymore. Snapshot id: $snap_id will be deleted.\n"
                     echo -e "Deleting the snapshots id: $snap_id \n"
                     aws ec2 delete-snapshot --snapshot-id "$snap_id"

--- a/aws_del_old_snaps.sh
+++ b/aws_del_old_snaps.sh
@@ -2,8 +2,7 @@
 # Script to delete old unpaired snapshots
 
 # Installing necessary tool for the script: awscli and jq
-sudo apt-get update
-sudo apt-get install awscli jq -y
+pip install awscli --upgrade --user
 
 # Current list of regions we work with
 aws_regions=("ca-central-1" "eu-central-1" "eu-west-1" "eu-west-2" "us-east-1" "us-east-2" "us-west-1" "us-west-2")
@@ -23,11 +22,12 @@ for reg in ${aws_regions[*]}; do
         sed -i '1s/^/{"Snapshots":/' /tmp/aws_snaps.json
         sed -i "$ a }" /tmp/aws_snaps.json
         tot_no_snaps=$(grep -c -i ID < /tmp/aws_snaps.json)
+        counter_del_snap=0
 
         if [ "$tot_no_snaps" -gt "0" ]; then
             # Finding if the AMI which the current snapshot has been created for still exist. If not, we can delete snapshot
             echo -e "Total of current snapshot is: $tot_no_snaps\n"
-            counter_del_snap=0
+
             index=0
             while [ "$index" -lt "$tot_no_snaps" ]; do
                  
@@ -72,8 +72,6 @@ for reg in ${aws_regions[*]}; do
         else
             echo -e "There are no available snapshots in the current region: $AWS_DEFAULT_REGION"
         fi
+        
+        echo -e "\nNo of deleted of snapshots: $counter_del_snap\nDone.\n"
 done
-
-echo -e "\nNo of deleted of snapshots: $counter_del_snap\nDone.\n"
-
-exit $?

--- a/aws_del_old_snaps.sh
+++ b/aws_del_old_snaps.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # Script to delete old unpaired snapshots
 
-# Installing necessary tool for the script: awscli and jq
-pip install awscli --upgrade --user
-
 # Current list of regions we work with
 aws_regions=("ca-central-1" "eu-central-1" "eu-west-1" "eu-west-2" "us-east-1" "us-east-2" "us-west-1" "us-west-2")
 

--- a/aws_del_old_snaps.sh
+++ b/aws_del_old_snaps.sh
@@ -2,14 +2,13 @@
 # Script to delete old unpaired snapshots
 
 # Installing necessary tool for the script: awscli and jq
-sudo apt-get update && sudo apt-get upgrade -y
+sudo apt-get update
 sudo apt-get install awscli jq -y
 
 # Current list of regions we work with
 aws_regions=("ca-central-1" "eu-central-1" "eu-west-1" "eu-west-2" "us-east-1" "us-east-2" "us-west-1" "us-west-2")
 
 echo -e "\n----------------------------------\n   $(date)   \n----------------------------------"
-#del_date=$(date +"%Y-%m-%d" --date="1 days ago")
 echo -e "Amazon Web Services - Looking for old unpaired snaposhots:\n "
 
 # Now we start the process of deregistering the old Kubenow AMI across all the other regions

--- a/gce_clean_images.sh
+++ b/gce_clean_images.sh
@@ -20,8 +20,7 @@ sudo apt-get update
 sudo apt-get install google-cloud-sdk jq -y
 
 # Performing authentication in GCE
-export GOOGLE_APPLICATION_CREDENTIALS="$HOME/gce-key.json"
-gcloud auth activate-service-account 12202776487-compute@developer.gserviceaccount.com --key-file="$GOOGLE_APPLICATION_CREDENTIALS" --project phenomenal-1145
+gcloud auth activate-service-account 12202776487-compute@developer.gserviceaccount.com --key-file="$GCE_KEY" --project phenomenal-1145
 
 echo -e "----------------------------------\n   $(date)   \n----------------------------------"
 del_date=$(date +"%Y-%m-%d" --date="1 days ago")

--- a/gce_clean_images.sh
+++ b/gce_clean_images.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Script to delete GCE images older than n no of days
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Installing necessary tool for the script: gce sdk kit and jq
+# Create an environment variable for the correct distribution
+CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
+export CLOUD_SDK_REPO
+
+# Add the Cloud SDK distribution URI as a package source
+echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+
+# Import the Google Cloud Platform public key
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+
+# Update the package list and install the Cloud SDK
+sudo apt-get update && sudo apt-get upgrade -y
+sudo apt-get install google-cloud-sdk jq -y
+
+# Performing authentication in GCE
+export GOOGLE_APPLICATION_CREDENTIALS="$HOME/gce-key.json"
+gcloud auth activate-service-account 12202776487-compute@developer.gserviceaccount.com --key-file="$GOOGLE_APPLICATION_CREDENTIALS" --project phenomenal-1145
+
+echo -e "----------------------------------\n   $(date)   \n----------------------------------"
+del_date=$(date +"%Y-%m-%d" --date="1 days ago")
+echo -e "Google Cloud Engine - Looking for old KubeNow's images:\n "
+
+# Extracting both KubeNow images that are flagged as "test" or "current"
+gcloud compute images list --filter='Name:kubenow-*-current OR Name:kubenow-*-test' --format=json > /tmp/gce_out_images.json
+sed -i '1s/^/{"Images":/' /tmp/gce_out_images.json
+sed -i "$ a }" /tmp/gce_out_images.json
+
+tot_no_images=$(grep -c -i "name" < /tmp/gce_out_images.json)
+
+if [ "$tot_no_images" -gt "0" ]; then
+    counter_del_img=0
+    # Finding Image names of images older than 3 days which needed to be deregistered
+    index=0
+    while [ "$index" -lt "$tot_no_images" ]; do
+        img_date=$(jq ".Images[$index] | .creationTimestamp" /tmp/gce_out_images.json | sed -e 's/^"//' -e 's/"$//' -e 's/T.*//')
+
+        if [ "$img_date" == "$del_date" ]; then
+            # Extracting image's "Name"
+            name=$(jq ".Images[$index] | .name" /tmp/gce_out_images.json | sed -e 's/^"//' -e 's/"$//')
+            echo -e "Following old image dated $img_date is found \nName: $name\n"               
+
+            # Deregistering the AMI
+            echo -e "Starting the deletion of image: $name...\n"
+            gcloud compute images delete "$name" -q
+            counter_del_img=$((counter_del_img+1))
+        fi
+        index=$((index+1))
+    done
+    
+    if [ "$counter_del_img" == "0" ]; then
+        echo -e "No old images dated $del_date were found \n"
+    fi
+    
+else
+    echo -e "No GCE KubeNow images flagged as test or current were found"
+fi
+
+# Extracting both KubeNow bucket objects that are flagged as "test" or "current"
+gsutil ls gs://kubenow-images/ | grep -E 'kubenow-v([0-9]*)([ab0-9]*)-([0-9]*)-([a-z0-9]*)-([test]*)([current]*).tar.gz([.exporter.log]*)' > /tmp/gce_bk_objs.txt
+tot_no_bk_obj=$(wc -l < /tmp/gce_bk_objs.txt)
+
+if [ "$tot_no_bk_obj" -gt "0" ]; then
+    counter_del_obj=0
+    # Finding Bucket object older than 3 days which needed to be deleted
+    echo -e "Looking for old KubeNow's Bucket Objects...\n "
+    while read -r line; do
+        gsutil ls -l "$line" | awk 'NR==1{print $3, $2}' > /tmp/gce_obj_details.txt
+        img_date=$(awk '{print $2}' /tmp/gce_obj_details.txt | sed -e 's/T.*//')
+
+        if [ "$img_date" == "$del_date" ]; then
+            # Extracting bkucet object's "name"
+            url=$(awk '{print $1}' /tmp/gce_obj_details.txt)
+            name=$(awk '{print $1}' /tmp/gce_obj_details.txt | sed 's/gs:\/\/kubenow-images\///g')
+            echo -e "\nFollowing old bucket object dated $img_date is found \nName: $name\n"               
+
+            # Deleting Bucket Object
+            echo -e "Starting the deletion of bucket object: $name...\n"
+            gsutil rm "$url"
+            counter_del_obj=$((counter_del_obj+1))
+        fi
+    done < /tmp/gce_bk_objs.txt
+    
+    if [ "$counter_del_obj" == "0" ]; then
+        echo -e "No old bucket objects dated $del_date were found \n"
+    fi
+    
+else
+    echo -e "No GCE KubeNow bucket objects flagged as test or current were found"
+fi
+
+echo -e "\nNo of deleted image: $counter_del_img\nNo of deleted bucket object: $counter_del_obj\nDone.\n"

--- a/gce_clean_images.sh
+++ b/gce_clean_images.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
-# Script to delete GCE images older than n no of days
+# shellcheck disable=SC2126
+# The above is an exception for the grep command around line 43, for variable tot_no_images
 
 # Exit immediately if a command exits with a non-zero status
+
 set -e
 
-# Installing necessary tool for the script: gce sdk kit and jq
+# Installing necessary tool for the script: gce sdk kit
 # Create an environment variable for the correct distribution
 CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)"
 export CLOUD_SDK_REPO
@@ -15,12 +17,16 @@ echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | sudo tee
 # Import the Google Cloud Platform public key
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 
-# Update the package list and install the Cloud SDK
-sudo apt-get update
-sudo apt-get install google-cloud-sdk jq -y
+# Install the Cloud SDK
+sudo apt-get update && sudo apt-get install google-cloud-sdk -y
+
+echo "$GCE_KEY" > ./account_file.json
 
 # Performing authentication in GCE
-gcloud auth activate-service-account 12202776487-compute@developer.gserviceaccount.com --key-file="$GCE_KEY" --project phenomenal-1145
+gcloud auth activate-service-account 12202776487-compute@developer.gserviceaccount.com --key-file="./account_file.json" --project phenomenal-1145
+
+# Testing that authentication worked
+gcloud auth list
 
 echo -e "----------------------------------\n   $(date)   \n----------------------------------"
 del_date=$(date +"%Y-%m-%d" --date="1 days ago")
@@ -31,10 +37,13 @@ gcloud compute images list --filter='Name:kubenow-*-current OR Name:kubenow-*-te
 sed -i '1s/^/{"Images":/' /tmp/gce_out_images.json
 sed -i "$ a }" /tmp/gce_out_images.json
 
-tot_no_images=$(grep -c -i "name" < /tmp/gce_out_images.json)
+# Reason why we are not directly using grep -c -i "name" is because of the set -e command
+# In fact when there are not test or current images, the counter is correctly set to 0, but grep's exit code is -1
+tot_no_images=$(grep -i "name" < /tmp/gce_out_images.json | wc -l)
+counter_del_img=0
 
 if [ "$tot_no_images" -gt "0" ]; then
-    counter_del_img=0
+
     # Finding Image names of images older than 1 day which needed to be deregistered
     index=0
     while [ "$index" -lt "$tot_no_images" ]; do
@@ -62,13 +71,16 @@ else
 fi
 
 # Extracting both KubeNow bucket objects that are flagged as "test" or "current"
-gsutil ls gs://kubenow-images/ | grep -E 'kubenow-v([0-9]*)([ab0-9]*)-([0-9]*)-([a-z0-9]*)-([test]*)([current]*).tar.gz([.exporter.log]*)' > /tmp/gce_bk_objs.txt
+# Same technicality here about the set -e at the beginning at grep's exit code -1. Thus using tee which no matter the outcomes, will return 0
+gsutil ls gs://kubenow-images/ | grep -E 'kubenow-v([0-9]*)([ab0-9]*)-([0-9]*)-([a-z0-9]*)-([test]*)([current]*).tar.gz([.exporter.log]*)' | tee /tmp/gce_bk_objs.txt
 tot_no_bk_obj=$(wc -l < /tmp/gce_bk_objs.txt)
+counter_del_obj=0
 
 if [ "$tot_no_bk_obj" -gt "0" ]; then
-    counter_del_obj=0
+    
     # Finding Bucket object older than 3 days which needed to be deleted
     echo -e "Looking for old KubeNow's Bucket Objects...\n "
+    
     while read -r line; do
         gsutil ls -l "$line" | awk 'NR==1{print $3, $2}' > /tmp/gce_obj_details.txt
         img_date=$(awk '{print $2}' /tmp/gce_obj_details.txt | sed -e 's/T.*//')

--- a/gce_clean_images.sh
+++ b/gce_clean_images.sh
@@ -16,7 +16,7 @@ echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | sudo tee
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
 
 # Update the package list and install the Cloud SDK
-sudo apt-get update && sudo apt-get upgrade -y
+sudo apt-get update
 sudo apt-get install google-cloud-sdk jq -y
 
 # Performing authentication in GCE
@@ -36,12 +36,12 @@ tot_no_images=$(grep -c -i "name" < /tmp/gce_out_images.json)
 
 if [ "$tot_no_images" -gt "0" ]; then
     counter_del_img=0
-    # Finding Image names of images older than 3 days which needed to be deregistered
+    # Finding Image names of images older than 1 day which needed to be deregistered
     index=0
     while [ "$index" -lt "$tot_no_images" ]; do
         img_date=$(jq ".Images[$index] | .creationTimestamp" /tmp/gce_out_images.json | sed -e 's/^"//' -e 's/"$//' -e 's/T.*//')
 
-        if [ "$img_date" == "$del_date" ]; then
+        if [[ ! "$img_date" > "$del_date" ]]; then
             # Extracting image's "Name"
             name=$(jq ".Images[$index] | .name" /tmp/gce_out_images.json | sed -e 's/^"//' -e 's/"$//')
             echo -e "Following old image dated $img_date is found \nName: $name\n"               
@@ -74,7 +74,7 @@ if [ "$tot_no_bk_obj" -gt "0" ]; then
         gsutil ls -l "$line" | awk 'NR==1{print $3, $2}' > /tmp/gce_obj_details.txt
         img_date=$(awk '{print $2}' /tmp/gce_obj_details.txt | sed -e 's/T.*//')
 
-        if [ "$img_date" == "$del_date" ]; then
+        if [[ ! "$img_date" > "$del_date" ]]; then
             # Extracting bkucet object's "name"
             url=$(awk '{print $1}' /tmp/gce_obj_details.txt)
             name=$(awk '{print $1}' /tmp/gce_obj_details.txt | sed 's/gs:\/\/kubenow-images\///g')

--- a/os_clean_images.sh
+++ b/os_clean_images.sh
@@ -37,7 +37,7 @@ if [ "$tot_no_images" -gt "0" ]; then
 
             # Deleting old KubeNow Image
             printf "Starting to delete old KubewNow image: %s...\n\n" "$id_to_delete"
-            glance image-delete $id_to_delete
+            glance image-delete "$id_to_delete"
             counter_del_img=$((counter_del_img+1))
             echo -e "Keep looking for any other old KubeNow image...\n"
         fi

--- a/os_clean_images.sh
+++ b/os_clean_images.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Script to delete Openstack private images older than n no of days
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Fix OS potential issue/bug: "sudo: unable to resolve host..."
+sudo sed -i /etc/hosts -e "s/^127.0.0.1 localhost$/127.0.0.1 localhost $(hostname)/"
+
+# Installing necessary tool for the script: awscli and jq
+sudo apt-get update && sudo apt-get install python-dev python-pip -y
+pip install --upgrade pip
+sudo pip install python-glanceclient
+
+echo -e "----------------------------------\n   $(date)   \n----------------------------------"
+del_date=$(date +"%Y-%m-%d" --date="1 days ago")
+echo "del_date: $del_date"
+echo -e "Openstack - Looking for old KubewNow images:\n "
+
+# Extracting both KubeNow images that are flagged as "test" or "current"
+glance image-list | grep -E 'kubenow-v([0-9]*)-([0-9]*)-([a-z0-9]*)-([test]*)([current]*)' | awk '{print $2, $4}' > /tmp/os_out_images.txt
+tot_no_images=$(wc -l < /tmp/os_out_images.txt)
+
+if [ "$tot_no_images" -gt "0" ]; then
+    counter_del_img=0
+    # Finding Image IDs of AMIs older than 3 days which needed to be deregistered
+    while read -r line; do
+        glance image-show "$(echo "$line" | awk '{print $1}')" > /tmp/os_img_details.txt
+        img_date=$(grep -i "created_at" < /tmp/os_img_details.txt | awk '{print $4}' | sed -e 's/T.*//')
+
+        if [ "$img_date" == "$del_date" ]; then
+            # Extracting image's "Name" and "ImageId"
+            id_to_delete=$(echo "$line" | awk '{print $1}')
+            name=$(echo "$line" | awk '{print $2}')
+            echo -e "Following old images dated $img_date is found \nName: $name \nID:$id_to_delete"           
+
+            # Deleting old KubeNow Image
+            printf "Starting to delete KubewNow image: %s...\n\n" "$id_to_delete"
+            glance image-delete $id_to_delete
+            counter_del_img=$((counter_del_img+1))
+            echo -e "Keep looking for any other old KubeNow images...\n"
+        fi
+    done < /tmp/os_out_images.txt
+    
+    if [ "$counter_del_img" == "0" ]; then
+        echo -e "No old images dated $del_date were found \n"
+    fi
+    
+else
+    echo -e "No KubeNow iamges flagged as test or current were found"
+fi
+
+echo -e "\nNo of deleted image: $counter_del_img\nDone.\n"

--- a/os_clean_images.sh
+++ b/os_clean_images.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Script to delete Openstack private images older than n no of days
 
 # Exit immediately if a command exits with a non-zero status
 set -e
@@ -7,23 +6,20 @@ set -e
 # Fix OS potential issue/bug: "sudo: unable to resolve host..."
 sudo sed -i /etc/hosts -e "s/^127.0.0.1 localhost$/127.0.0.1 localhost $(hostname)/"
 
-# Installing necessary tool for the script: awscli and jq
-sudo apt-get update
-sudo apt-get install python-dev python-pip -y
-pip install --upgrade pip
-sudo pip install python-glanceclient
+# Installing necessary tool for the script: python-glanceclient
+pip install python-glanceclient
 
 echo -e "----------------------------------\n   $(date)   \n----------------------------------"
 del_date=$(date +"%Y-%m-%d" --date="1 days ago")
-echo "del_date: $del_date"
 echo -e "Openstack - Looking for old KubewNow images:\n "
 
 # Extracting both KubeNow images that are flagged as "test" or "current"
 glance image-list | grep -E 'kubenow-v([0-9]*)-([0-9]*)-([a-z0-9]*)-([test]*)([current]*)' | awk '{print $2, $4}' > /tmp/os_out_images.txt
 tot_no_images=$(wc -l < /tmp/os_out_images.txt)
+counter_del_img=0
 
 if [ "$tot_no_images" -gt "0" ]; then
-    counter_del_img=0
+    
     # Finding Image IDs of AMIs older than 1 day which needed to be deregistered
     while read -r line; do
         glance image-show "$(echo "$line" | awk '{print $1}')" > /tmp/os_img_details.txt


### PR DESCRIPTION
@mcapuccini 
Here is a first version of the scripts meant to be added as cron jobs in Travis for KubeNow.

They all have been tested by spawning a Ubuntu Xenial machine in one of our provider. Hence script have been run remotely in a Linux environment.

Tests have been performed and were successful both locally and **safely** in production.

For the time being I have not added them in Travis. Thus if need be, you need to first source the related providers and then run one or all the scripts in a Linux (must be Debian based though) machine.

**NB!!!** Currently the deleting date to be used as reference is hard-coded and needs to be manually tweaked as long as we will not decide a precise span of time for which items can be considered "old". Here is the line of code mentioned and to be manually set:

`del_date=$(date +"%Y-%m-%d" --date="1 days ago")`

As you can see in all four scripts `del_date` is currently set to `1 days ago`

Any comments, suggestions, critique, please feel free!

**P.S.: This solve:** https://github.com/kubenow/KubeNow/issues/202