### PR TITLE
Installing azure-cli via pip instead of apt-get

### DIFF
--- a/az_clean_images.sh
+++ b/az_clean_images.sh
@@ -1,20 +1,11 @@
 #!/bin/bash
 
-# Related to bug fix: https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627
-sudo aptitude upgrade dpkg -y
+# Exit immediately if a command exits with a non-zero status
+set -e
 
 # Installing Azure command-line client
-echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
-
-sudo apt-key adv --keyserver packages.microsoft.com --recv-keys 52E16F86FEE04B979B07E28DB02C46DF417A0893
-sudo apt-get install apt-transport-https
-sudo apt-get update && sudo apt-get install azure-cli -y
-
-# Exit immediately if a command exits with a non-zero status
-# Usually this is set at the beginning of the script. But due to bug:
-# https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627
-# this need to be temporarily displaced
-set -e
+sudo pip install --upgrade pip
+sudo pip install azure-cli
 
 echo -e "----------------------------------\n   $(date)   \n----------------------------------"
 del_date=$(date +"%Y-%m-%d" --date="1 days ago")


### PR DESCRIPTION
## Change content and motivation
Due to a potentially still occurring [dpkg bug](https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627), we are installing azure-cli via pip instead of apt-get.

## GitHub cross-links 
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
**Fixes:** <!-- fixes #X, fixes #Y, ... fixes #Z --> https://github.com/kubenow/KubeNow/issues/309
