### PR TITLE
Fixing incorrect owner id after aws migration

### DIFF
--- a/aws_clean_images.sh
+++ b/aws_clean_images.sh
@@ -8,6 +8,10 @@ set -e
 # Installing necessary tool for the script: awscli
 pip install -qq awscli --upgrade
 
+# Account/Owner ID (also good for possible future migration)
+AWS_OWNER_ID=$(aws sts get-caller-identity --output text --query 'Account')
+export AWS_OWNER_ID
+
 # Execute different script only for AWS and before main ones
 # Reason is to avoid concurrent APIs call (e.g. deletion of an AMI and checking if that AMI exists)
 bash aws_del_old_snaps.sh
@@ -28,7 +32,7 @@ for reg in ${aws_regions[*]}; do
 
   # Extracting both KubeNow images that are flagged as "test" or "current"
   # Using tee and wc -l (which often returns 0) because of set -e. In case aws and grep return 1
-  aws ec2 describe-images --filters "Name=name,Values=kubenow-*-*" "Name=owner-id,Values=105135433346" | tee /tmp/aws_out_images.json
+  aws ec2 describe-images --filters "Name=name,Values=kubenow-*-*" "Name=owner-id,Values=$AWS_OWNER_ID" | tee /tmp/aws_out_images.json
   tot_no_amis=$(grep -i "imageid" </tmp/aws_out_images.json | wc -l)
   counter_del_img=0
   counter_del_snap=0

--- a/aws_del_old_snaps.sh
+++ b/aws_del_old_snaps.sh
@@ -15,7 +15,7 @@ for reg in ${aws_regions[*]}; do
   echo -e "Current region is: $AWS_DEFAULT_REGION\n"
 
   # Extracting both KubeNow images that are flagged as "test" or "current"
-  aws ec2 describe-snapshots --owner-ids 105135433346 --query 'Snapshots[*].{ID:SnapshotId,Description:Description}' >/tmp/aws_snaps.json
+  aws ec2 describe-snapshots --owner-ids "$AWS_OWNER_ID" --query 'Snapshots[*].{ID:SnapshotId,Description:Description}' >/tmp/aws_snaps.json
   sed -i '1s/^/{"Snapshots":/' /tmp/aws_snaps.json
   sed -i "$ a }" /tmp/aws_snaps.json
   tot_no_snaps=$(grep -c -i ID </tmp/aws_snaps.json)


### PR DESCRIPTION
## Change content and motivation
<!-- please describe briefly the content of this PR, and motivate why this changes are needed -->

Despite cron was running successfully in AWS, I noticed that old images and snapshots were not being removed. This is true since we've migrated to the new AWS account and is related to using the incorrect former owner id that was hard-coded.

Now I am pulling it via the related API call and save it in a global variables for the AWS scripts. 